### PR TITLE
OY-5422: Virkistä tiedostovälimuisti taustalla

### DIFF
--- a/src/main/java/fi/vm/sade/lokalisointi/storage/ExtendedDokumenttipalvelu.java
+++ b/src/main/java/fi/vm/sade/lokalisointi/storage/ExtendedDokumenttipalvelu.java
@@ -6,7 +6,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.scheduling.annotation.Scheduled;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
@@ -50,13 +49,12 @@ public class ExtendedDokumenttipalvelu extends Dokumenttipalvelu {
         .join();
   }
 
-  @Cacheable("find")
+  @Cacheable(value = "find", sync = true)
   public Collection<ObjectMetadata> cachedFind(final Collection<String> terms) {
     return find(terms);
   }
 
   @CacheEvict(value = "find", allEntries = true)
-  @Scheduled(fixedRateString = "${lokalisointi.find-cache-ttl-ms}")
   public void emptyFindCache() {
     LOG.debug("Emptying find cache");
   }

--- a/src/main/java/fi/vm/sade/lokalisointi/storage/ExtendedDokumenttipalvelu.java
+++ b/src/main/java/fi/vm/sade/lokalisointi/storage/ExtendedDokumenttipalvelu.java
@@ -51,6 +51,7 @@ public class ExtendedDokumenttipalvelu extends Dokumenttipalvelu {
 
   @Cacheable(value = "find", sync = true)
   public Collection<ObjectMetadata> cachedFind(final Collection<String> terms) {
+    LOG.info("Searching for {}", terms);
     return find(terms);
   }
 

--- a/src/main/java/fi/vm/sade/lokalisointi/storage/S3.java
+++ b/src/main/java/fi/vm/sade/lokalisointi/storage/S3.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
@@ -76,6 +77,13 @@ public class S3 implements InitializingBean {
   @Override
   public void afterPropertiesSet() throws Exception {
     LOG.info("tolgeeSlug: {}", tolgeeSlug);
+  }
+
+  @Scheduled(fixedRateString = "${lokalisointi.find-cache-ttl-ms}")
+  public void refreshFindCache() {
+    LOG.debug("Refreshing find cache");
+    dokumenttipalvelu.emptyFindCache();
+    dokumenttipalvelu.cachedFind(List.of(LOKALISOINTI_TAG));
   }
 
   @Autowired

--- a/src/main/java/fi/vm/sade/lokalisointi/storage/S3.java
+++ b/src/main/java/fi/vm/sade/lokalisointi/storage/S3.java
@@ -81,7 +81,7 @@ public class S3 implements InitializingBean {
 
   @Scheduled(fixedRateString = "${lokalisointi.find-cache-ttl-ms}")
   public void refreshFindCache() {
-    LOG.debug("Refreshing find cache");
+    LOG.info("Refreshing find cache");
     dokumenttipalvelu.emptyFindCache();
     dokumenttipalvelu.cachedFind(List.of(LOKALISOINTI_TAG));
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -98,8 +98,8 @@ tolgee:
 logging:
   level:
     root: info
-    fi.vm.sade.valinta.dokumenttipalvelu: warn
-    fi.vm.sade.lokalisointi.storage.ExtendedDokumenttipalvelu: warn
+    fi.vm.sade.valinta.dokumenttipalvelu: info
+    fi.vm.sade.lokalisointi.storage.ExtendedDokumenttipalvelu: info
 
 # TODO siirrä nämä templateen
 host:


### PR DESCRIPTION
https://jira.eduuni.fi/browse/OY-5422

Yhteenveto mitä muutettiin ja miksi:

Juurisyy: `@CacheEvict` + `@Scheduled` -yhdistelmä aiheutti kaksi ongelmaa:

1. Kun välimuisti tyhjeni, kaikki samanaikaiset pyynnöt kutsuivat S3:a rinnakkain. Jokainen odotti omaa S3-vastaustaan.
2. Reaktiivinen välimuistin virkistys: S3-haku käynnistyi vasta kun käyttäjäpyyntö saapui tyhjään välimuistiin.

Korjaukset:

- `@Cacheable(sync = true)` `ExtendedDokumenttipalvelu`:ssa varmistaa, että samalle avaimelle tehdään kerrallaan vain yksi S3-kutsu. Muut säikeet odottavat sen valmistumista sen sijaan, että kukin tekisi oman kutsunsa.
- `refreshFindCache()` S3:ssa (`@Scheduled`): Aikataulutettu välimuistin virkistys siirrettiin `S3.java`:an. Virkistys ensin tyhjentää välimuistin ja välittömästi täyttää sen uudelleen schedulerin omalla säikeellä, ennen kuin yksikään käyttäjäpyyntö osuu tyhjään välimuistiin.